### PR TITLE
Add the "expected" configuration to find ICU4C

### DIFF
--- a/cmake-modules/FindICU.cmake
+++ b/cmake-modules/FindICU.cmake
@@ -1,0 +1,32 @@
+# - Find ICUUC
+# Find the native ICUUC includes and library
+#
+#   ICUUC_FOUND        - True if ICUUC found.
+#   ICUUC_INCLUDE_DIRS - where to find unicode/unistr.h, etc.
+#   ICUUC_LIBRARIES    - List of libraries when using ICUUC.
+#
+
+if( ICUUC_INCLUDE_DIR )
+    # Already in cache, be silent
+    set( ICUUC_FIND_QUIETLY TRUE )
+endif()
+
+find_path( ICUUC_INCLUDE_DIR unicode/unistr.h )
+
+find_library( ICUUC_LIBRARY
+              NAMES icuuc )
+
+# handle the QUIETLY and REQUIRED arguments and set ICUUC_FOUND to TRUE if
+# all listed variables are TRUE
+include( FindPackageHandleStandardArgs )
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( ICUUC DEFAULT_MSG ICUUC_LIBRARY ICUUC_INCLUDE_DIR )
+
+mark_as_advanced( ICUUC_INCLUDE_DIR ICUUC_LIBRARY )
+
+if(ICUUC_FOUND)
+  set(ICUUC_INCLUDE_DIRS ${ICUUC_INCLUDE_DIR})
+  set(ICUUC_LIBRARIES ${ICUUC_LIBRARY})
+else()
+  set(ICUUC_INCLUDE_DIRS)
+  set(ICUUC_LIBRARIES)
+endif()


### PR DESCRIPTION
Resolves the issue originally documented in https://github.com/jpd002/Play-/pull/568

```
CMake Warning at ~/PlayEmulator/Dependencies/boost-cmake/libs/locale.cmake:26 (find_package):
  By not providing "FindICU.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "ICU", but
  CMake did not find one.

  Could not find a package configuration file provided by "ICU" with any of
  the following names:

    ICUConfig.cmake
    icu-config.cmake

  Add the installation prefix of "ICU" to CMAKE_PREFIX_PATH or set "ICU_DIR"
  to a directory containing one of the above files.  If "ICU" provides a
  separate development package or SDK, be sure it has been installed.
```
