### PR TITLE
cmake: icuuc NO_CMAKE_PATH

### DIFF
--- a/cmake-modules/FindICUUC.cmake
+++ b/cmake-modules/FindICUUC.cmake
@@ -14,7 +14,7 @@ endif()
 find_path( ICUUC_INCLUDE_DIR unicode/unistr.h )
 
 find_library( ICUUC_LIBRARY
-              NAMES icuuc )
+              NAMES icuuc NO_CMAKE_PATH)
 
 # handle the QUIETLY and REQUIRED arguments and set ICUUC_FOUND to TRUE if
 # all listed variables are TRUE


### PR DESCRIPTION
this fixes breaking build on qt 5.8 using qt creator, as cmake uses qt's provided icu library but system headers, causing a mismatch and undefined error.