### PR TITLE
silence warning of unrarsrc

### DIFF
--- a/build_cmake/unrarsrc-5.2.5/CMakeLists.txt
+++ b/build_cmake/unrarsrc-5.2.5/CMakeLists.txt
@@ -54,5 +54,8 @@ set(unrar_srcs
 )
 
 add_library(unrar ${unrar_srcs})
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_C_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+	target_compile_options(unrar PRIVATE "-w")
+endif()
 target_compile_definitions(unrar PRIVATE -DSILENT)
 target_include_directories(unrar PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../unrarsrc-5.2.5/)


### PR DESCRIPTION
those warnings are not needed and would probably won't be missed either.

this dependency generates about 300+ warning, and without them, I'm able to get Travis https://travis-ci.org/Zer0xFF/Play-/jobs/482677873 to build iOS, that build is TGDB_API branch (thus shared_covers) + Qt covers related changes(though they have no application to that build).