### PR TITLE
allow reading files greater than 2GB on 32bit linux

### DIFF
--- a/cmake-modules/Header.cmake
+++ b/cmake-modules/Header.cmake
@@ -69,5 +69,8 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL "${CMAKE_SOURCE_DIR}")
 				MESSAGE(FATAL_ERROR "VTUNE_PATH was not defined")
 			endif()
 		endif()
+	elseif(TARGET_PLATFORM_UNIX)
+		# RPI 32bit require this to be able to read files bigger than 2GB
+		add_definitions(-D_FILE_OFFSET_BITS=64)
 	endif()
 endif()


### PR DESCRIPTION
this should fix this issue https://github.com/jpd002/Play-/issues/769

Note: I dont have fast enough ARM (32bit) device to test this, but this has been tested indirectly
![image](https://user-images.githubusercontent.com/5013823/69149045-8db14580-0acd-11ea-976c-01990741bd14.png)
