### PR TITLE
Remove flatpak-shared-modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "ghc_filesystem"]
 	path = ghc_filesystem
 	url = https://github.com/gulrak/filesystem.git
-[submodule "flatpak-shared-modules"]
-	path = flatpak-shared-modules
-	url = https://github.com/flathub/shared-modules.git


### PR DESCRIPTION
Removes the flatpak-shared-modules submodule introduced by #32 .
I've always seen it used directly on the Flatpak's repository, which does not "pollute" the parent project and allows easier maintenance for the packagers.